### PR TITLE
Fixed dependency issue whit gradle 7+

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile 'net.portswigger.burp.extender:burp-extender-api:1.7.13'
+    implementation 'net.portswigger.burp.extender:burp-extender-api:1.7.13'
 }
 
 sourceSets {


### PR DESCRIPTION
Changed the burp dependency from a compile to implementation since compile
no longer works in gradle 7.